### PR TITLE
API error handling function

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,9 +3,143 @@ package errors
 import (
 	"fmt"
 	"log"
+	"net/http"
 )
 
 const help = "Please make a new issue if you think this is a bug: https://lichess-tui/issues."
+
+// Handles the request response. If the request response status
+// code is >= 400 and < 600, then the application crashes with
+// a unique error screen message for each status code and writes
+// a log message with the contents of the request and the contents
+// of the response gotten.
+//
+// Otherwise the function returns 0.
+//
+// Not every status code is supported. If the function hits an
+// unsupported status code, it returns 1.
+//
+// Supported status codes:
+//    400 - bad request.
+//    401 - unauthorized.
+//    404 - not found.
+//    408 - request timeout.
+//    418 - teapot.
+//    429 - too many requests.
+//    500 - internal server error.
+//    501 - not implemented.
+//    502 - bad gateway.
+func HandleRequestResponse(req *http.Request, res *http.Response) int {
+  var status = res.StatusCode;
+  if status < 400 {
+    return 0
+  }
+
+  switch status {
+  case http.StatusBadRequest: {
+    fmt.Println("  _  _    ___   ___    ____            _                                  _ ")
+    fmt.Println(" | || |  / _ \\ / _ \\  | __ )  __ _  __| |  _ __ ___  __ _ _   _  ___  ___| |_ ")
+    fmt.Println(" | || |_| | | | | | | |  _ \\ / _` |/ _` | | '__/ _ \\/ _` | | | |/ _ \\/ __| __|")
+    fmt.Println(" |__   _| |_| | |_| | | |_) | (_| | (_| | | | |  __/ (_| | |_| |  __/\\__ \\ |_ ")
+    fmt.Println("    |_|  \\___/ \\___/  |____/ \\__,_|\\__,_| |_|  \\___|\\__, |\\__,_|\\___||___/\\__|")
+    fmt.Println("                                                       |_|                    ")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  case http.StatusUnauthorized: {
+    fmt.Println("  _  _    ___  _   _   _                   _   _                _             _ ")
+    fmt.Println(" | || |  / _ \\/ | | | | |_ __   __ _ _   _| |_| |__   ___  _ __(_)_______  __| |")
+    fmt.Println(" | || |_| | | | | | | | | '_ \\ / _` | | | | __| '_ \\ / _ \\| '__| |_  / _ \\/ _` |")
+    fmt.Println(" |__   _| |_| | | | |_| | | | | (_| | |_| | |_| | | | (_) | |  | |/ /  __/ (_| |")
+    fmt.Println("    |_|  \\___/|_|  \\___/|_| |_|\\__,_|\\__,_|\\__|_| |_|\\___/|_|  |_/___\\___|\\__,_|")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  case http.StatusNotFound: {
+    fmt.Println("  _  _    ___  _  _    __        ___                                                                          _           ___ ")
+    fmt.Println(" | || |  / _ \\| || |   \\ \\      / / |__   ___     __ _ _ __ ___   _   _  ___  _   _  __      ____ _ _ __ _ __(_) ___  _ _|__ \\")
+    fmt.Println(" | || |_| | | | || |_   \\ \\ /\\ / /| '_ \\ / _ \\   / _` | '__/ _ \\ | | | |/ _ \\| | | | \\ \\ /\\ / / _` | '__| '__| |/ _ \\| '__|/ /")
+    fmt.Println(" |__   _| |_| |__   _|   \\ V  V / | | | | (_) | | (_| | | |  __/ | |_| | (_) | |_| |  \\ V  V / (_| | |  | |  | | (_) | |  |_| ")
+    fmt.Println("    |_|  \\___/   |_|      \\_/\\_/  |_| |_|\\___/   \\__,_|_|  \\___|  \\__, |\\___/ \\__,_|   \\_/\\_/ \\__,_|_|  |_|  |_|\\___/|_|  (_) ")
+    fmt.Println("                                                                  |___/                                                       ")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  case http.StatusRequestTimeout: {
+    fmt.Println("  _  _    ___   ___    _____ _                    _               _   ")
+    fmt.Println(" | || |  / _ \\ ( _ )  |_   _(_)_ __ ___   ___  __| |   ___  _   _| |_ ")
+    fmt.Println(" | || |_| | | |/ _ \\    | | | | '_ ` _ \\ / _ \\/ _` |  / _ \\| | | | __|")
+    fmt.Println(" |__   _| |_| | (_) |   | | | | | | | | |  __/ (_| | | (_) | |_| | |_ ")
+    fmt.Println("    |_|  \\___/ \\___/    |_| |_|_| |_| |_|\\___|\\__,_|  \\___/ \\__,_|\\__|")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  // Lol, you must do really hard job to achieve
+  // this one.
+  case http.StatusTeapot: {
+    fmt.Println("  _  _   _  ___    ___ _   _       _               _   _                    _             _ _  ___ ")
+    fmt.Println(" | || | / |( _ )  |_ _| |_( )___  | |_ ___  __ _  | |_(_)_ __ ___   ___    (_)_ __  _ __ (_) ||__ \\")
+    fmt.Println(" | || |_| |/ _ \\   | || __|// __| | __/ _ \\/ _` | | __| | '_ ` _ \\ / _ \\   | | '_ \\| '_ \\| | __|/ /")
+    fmt.Println(" |__   _| | (_) |  | || |_  \\__ \\ | ||  __/ (_| | | |_| | | | | | |  __/_  | | | | | | | | | |_|_| ")
+    fmt.Println("    |_| |_|\\___/  |___|\\__| |___/  \\__\\___|\\__,_|  \\__|_|_| |_| |_|\\___( ) |_|_| |_|_| |_|_|\\__(_) ")
+    fmt.Println("                                                                       |/                          ")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  case http.StatusTooManyRequests: {
+    fmt.Println("  _  _  ____   ___    _____                                                                          _       ")
+    fmt.Println(" | || ||___ \\ / _ \\  |_   _|__   ___    _ __ ___   __ _ _ __  _   _   _ __ ___  __ _ _   _  ___  ___| |_ ___ ")
+    fmt.Println(" | || |_ __) | (_) |   | |/ _ \\ / _ \\  | '_ ` _ \\ / _` | '_ \\| | | | | '__/ _ \\/ _` | | | |/ _ \\/ __| __/ __|")
+    fmt.Println(" |__   _/ __/ \\__, |   | | (_) | (_) | | | | | | | (_| | | | | |_| | | | |  __/ (_| | |_| |  __/\\__ \\ |_\\__ \\")
+    fmt.Println("    |_||_____|  /_/    |_|\\___/ \\___/  |_| |_| |_|\\__,_|_| |_|\\__, | |_|  \\___|\\__, |\\__,_|\\___||___/\\__|___/")
+    fmt.Println("                                                              |___/               |_|                        ")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+
+  case http.StatusInternalServerError: {
+    fmt.Println("  ____   ___   ___    ___       _                        _                                                           ")
+    fmt.Println(" | ___| / _ \\ / _ \\  |_ _|_ __ | |_ ___ _ __ _ __   __ _| |  ___  ___ _ ____   _____ _ __    ___ _ __ _ __ ___  _ __ ")
+    fmt.Println(" |___ \\| | | | | | |  | || '_ \\| __/ _ \\ '__| '_ \\ / _` | | / __|/ _ \\ '__\\ \\ / / _ \\ '__|  / _ \\ '__| '__/ _ \\| '__|")
+    fmt.Println("  ___) | |_| | |_| |  | || | | | ||  __/ |  | | | | (_| | | \\__ \\  __/ |   \\ V /  __/ |    |  __/ |  | | | (_) | |   ")
+    fmt.Println(" |____/ \\___/ \\___/  |___|_| |_|\\__\\___|_|  |_| |_|\\__,_|_| |___/\\___|_|    \\_/ \\___|_|     \\___|_|  |_|  \\___/|_|   ")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  case http.StatusNotImplemented: {
+    fmt.Println("  ____   ___  _   _   _       _     _                 _                           _           _ ")
+    fmt.Println(" | ___| / _ \\/ | | \\ | | ___ | |_  (_)_ __ ___  _ __ | | ___ _ __ ___   ___ _ __ | |_ ___  __| |")
+    fmt.Println(" |___ \\| | | | | |  \\| |/ _ \\| __| | | '_ ` _ \\| '_ \\| |/ _ \\ '_ ` _ \\ / _ \\ '_ \\| __/ _ \\/ _` |")
+    fmt.Println("  ___) | |_| | | | |\\  | (_) | |_  | | | | | | | |_) | |  __/ | | | | |  __/ | | | ||  __/ (_| |")
+    fmt.Println(" |____/ \\___/|_| |_| \\_|\\___/ \\__| |_|_| |_| |_| .__/|_|\\___|_| |_| |_|\\___|_| |_|\\__\\___|\\__,_|")
+    fmt.Println("                                               |_|                                              ")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  case http.StatusBadGateway: {
+    fmt.Println("  ____   ___ ____    ____            _               _                           ")
+    fmt.Println(" | ___| / _ \\___ \\  | __ )  __ _  __| |   __ _  __ _| |_ _____      ____ _ _   _ ")
+    fmt.Println(" |___ \\| | | |__) | |  _ \\ / _` |/ _` |  / _` |/ _` | __/ _ \\ \\ /\\ / / _` | | | |")
+    fmt.Println("  ___) | |_| / __/  | |_) | (_| | (_| | | (_| | (_| | ||  __/\\ V  V / (_| | |_| |")
+    fmt.Println(" |____/ \\___/_____| |____/ \\__,_|\\__,_|  \\__, |\\__,_|\\__\\___| \\_/\\_/ \\__,_|\\__, |")
+    fmt.Println("                                         |___/                             |___/ ")
+
+    fmt.Println(help)
+    log.Fatalf("The request %v got response %v", req, res)
+  }
+  }
+  // I couldn't trick the compiler to accept the default
+  // case return of 1, so I had to do it here.
+  return 1
+}
 
 func RequestError(err error) {
 	fmt.Println(help)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -29,9 +29,9 @@ const help = "Please make a new issue if you think this is a bug: https://liches
 //    500 - internal server error.
 //    501 - not implemented.
 //    502 - bad gateway.
-func HandleRequestResponse(req *http.Request, res *http.Response) int {
+func HandleRequestResponse(req *http.Request, res *http.Response, err error) int {
   var status = res.StatusCode;
-  if status < 400 {
+  if status < 400 && err == nil{
     return 0
   }
 
@@ -45,7 +45,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("                                                       |_|                    ")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   case http.StatusUnauthorized: {
     fmt.Println("  _  _    ___  _   _   _                   _   _                _             _ ")
@@ -55,7 +55,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("    |_|  \\___/|_|  \\___/|_| |_|\\__,_|\\__,_|\\__|_| |_|\\___/|_|  |_/___\\___|\\__,_|")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   case http.StatusNotFound: {
     fmt.Println("  _  _    ___  _  _    __        ___                                                                          _           ___ ")
@@ -66,7 +66,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("                                                                  |___/                                                       ")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   case http.StatusRequestTimeout: {
     fmt.Println("  _  _    ___   ___    _____ _                    _               _   ")
@@ -76,7 +76,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("    |_|  \\___/ \\___/    |_| |_|_| |_| |_|\\___|\\__,_|  \\___/ \\__,_|\\__|")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   // Lol, you must do really hard job to achieve
   // this one.
@@ -89,7 +89,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("                                                                       |/                          ")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   case http.StatusTooManyRequests: {
     fmt.Println("  _  _  ____   ___    _____                                                                          _       ")
@@ -100,7 +100,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("                                                              |___/               |_|                        ")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
 
   case http.StatusInternalServerError: {
@@ -111,7 +111,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println(" |____/ \\___/ \\___/  |___|_| |_|\\__\\___|_|  |_| |_|\\__,_|_| |___/\\___|_|    \\_/ \\___|_|     \\___|_|  |_|  \\___/|_|   ")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   case http.StatusNotImplemented: {
     fmt.Println("  ____   ___  _   _   _       _     _                 _                           _           _ ")
@@ -122,7 +122,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("                                               |_|                                              ")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   case http.StatusBadGateway: {
     fmt.Println("  ____   ___ ____    ____            _               _                           ")
@@ -133,7 +133,7 @@ func HandleRequestResponse(req *http.Request, res *http.Response) int {
     fmt.Println("                                         |___/                             |___/ ")
 
     fmt.Println(help)
-    log.Fatalf("The request %v got response %v", req, res)
+    log.Fatalf("The request %v got response %v\nError: %v", req, res, err)
   }
   }
   // I couldn't trick the compiler to accept the default

--- a/internal/requests/account.go
+++ b/internal/requests/account.go
@@ -179,7 +179,7 @@ func GetProfile(token string) Profile {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 
@@ -208,7 +208,7 @@ func GetEmailAddress(token string) EmailAddress {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/requests/events.go
+++ b/internal/requests/events.go
@@ -102,7 +102,7 @@ func StreamIncomingEvents(token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/requests/games.go
+++ b/internal/requests/games.go
@@ -35,7 +35,7 @@ func SeekGame(body SeekGameConfig, token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 
 	defer resp.Body.Close()
@@ -81,7 +81,7 @@ func GetOngoingGames(token string, respVar *OngoingGames) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 
@@ -115,7 +115,7 @@ func GameOperation(gameId string, operation string, token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 
 	defer resp.Body.Close()
@@ -150,7 +150,7 @@ func Move(gameId string, move string, body MoveConfig, token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 
 	defer resp.Body.Close()
@@ -228,7 +228,7 @@ func StreamBoardState(gameId string, token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 
@@ -296,7 +296,7 @@ func StreamGameMoves(gameId string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/requests/messaging.go
+++ b/internal/requests/messaging.go
@@ -32,7 +32,7 @@ func SendMessage(user string, body SendMessageConfig, token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 
 	defer resp.Body.Close()

--- a/internal/requests/relations.go
+++ b/internal/requests/relations.go
@@ -30,7 +30,7 @@ func ToggleFollowUser(user string, follow bool, token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 }
@@ -58,7 +58,7 @@ func ToggleBlockUser(user string, block bool, token string) {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 }

--- a/internal/requests/token.go
+++ b/internal/requests/token.go
@@ -30,7 +30,7 @@ func GetTokenInfo(token string) TokenInfo {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		errors.RequestError(err)
+    errors.HandleRequestResponse(req, resp, err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Each API call response, if an error is present is sent to `HandleRequestResponse` function which in case of a status code that's >= 400 and < 600 displays a unique error screen to the end user, indicating that there was an error. The further information is logged with `Fatalf`.

This pull request also should close https://github.com/proh14/lichess-tui/issues/1 issue.